### PR TITLE
Improve kv cache save modeling with memory features

### DIFF
--- a/run_simulation.py
+++ b/run_simulation.py
@@ -98,7 +98,8 @@ base_command = (
     "--replica_scheduler_config_type vllm_v1 "
     "--vllm_v1_scheduler_config_chunk_size 8192 "
     "--vllm_v1_scheduler_config_batch_size_cap 512 "
-    f"--metrics_config_output_dir {BASE_LOG_DIR}"
+    f"--metrics_config_output_dir {BASE_LOG_DIR} "
+    "--execution_time_predictor_config_cache_mode ignore_cache "
     #"--cache_config_enable_prefix_caching"
 )
 


### PR DESCRIPTION
## Summary
- profile attention to capture KV cache memory bytes
- include memory allocation in `attn_kv_cache_save` predictor training and lookup
- ensure simulations retrain execution-time models by ignoring cached models

## Testing
- `pytest` *(fails: SyntaxError in tests/unit/test_qwen_model_profiling.py)*

------
https://chatgpt.com/codex/tasks/task_e_68943bfcc4688327856b2078da3e06fb